### PR TITLE
setup_platform() must specify the port parameter when calling listContainers.

### DIFF
--- a/custom_components/switch/hadockermon.py
+++ b/custom_components/switch/hadockermon.py
@@ -15,7 +15,7 @@ from homeassistant.util import slugify
 from homeassistant.components.switch import (SwitchDevice,
     PLATFORM_SCHEMA, ENTITY_ID_FORMAT)
 
-__version__ = '2.0.5'
+__version__ = '2.0.6'
 
 REQUIREMENTS = ['pydockermon==0.0.1']
 

--- a/custom_components/switch/hadockermon.py
+++ b/custom_components/switch/hadockermon.py
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     stats = config.get(CONF_STATS)
     prefix = config.get(CONF_PREFIX)
     dev = []
-    containers = dm.listContainers(host)
+    containers = dm.listContainers(host, port)
     if containers:
         for container in containers:
             containername = container['Names'][0][1:]


### PR DESCRIPTION
setup_platform() must specify the port parameter when calling listContainers since the port parameter might be configured to something other than the default value.