### PR TITLE
Add support for specifying a username and password to be used for the HA-Dockermon HTTP request authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ To start using this make sure you have [ha-dockermon](https://github.com/philhaw
   
 ***
 Due to how `custom_componentes` are loaded, it is normal to see a `ModuleNotFoundError` error on first boot after adding this, to resolve it, restart Home-Assistant.
+
+***
+
+[buymeacoffee.com](https://www.buymeacoffee.com/ludeeus)

--- a/custom_components/switch/hadockermon.py
+++ b/custom_components/switch/hadockermon.py
@@ -17,7 +17,7 @@ from homeassistant.components.switch import (SwitchDevice,
 
 __version__ = '2.0.5'
 
-REQUIREMENTS = ['pydockermon==0.0.2']
+REQUIREMENTS = ['pydockermon==0.0.3']
 
 CONF_HOST = 'host'
 CONF_PORT = 'port'

--- a/custom_components/switch/hadockermon.py
+++ b/custom_components/switch/hadockermon.py
@@ -17,7 +17,7 @@ from homeassistant.components.switch import (SwitchDevice,
 
 __version__ = '2.0.5'
 
-REQUIREMENTS = ['pydockermon==0.0.1']
+REQUIREMENTS = ['pydockermon==0.0.2']
 
 CONF_HOST = 'host'
 CONF_PORT = 'port'


### PR DESCRIPTION
Thank you for accepting the patches so far :-)

This one adds support for specifying a username and password to be used for the HA-Dockermon HTTP request authentication.

I have tested this change by patching my Home Assistant installation and it all seems to work correctly.

"Update the required version of pydockermon to 0.0.3 (instead of 0.0.2) in hopeful anticipation of the acceptance of the pull/merge request (https://gitlab.com/ludeeus/pydockermon/merge_requests/1) that adds basic HTTP request authentication to pydockermon."

The only remaining issue with this pull request is the assumption that the next pydockermon release will be version 0.0.3.