### PR TITLE
Allow custom device name with formatting

### DIFF
--- a/custom_components/switch/hadockermon.py
+++ b/custom_components/switch/hadockermon.py
@@ -17,7 +17,7 @@ from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME,
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-__version__ = '3.0.1'
+__version__ = '3.1.0'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/switch/hadockermon.py
+++ b/custom_components/switch/hadockermon.py
@@ -22,7 +22,8 @@ __version__ = '3.0.1'
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['pydockermon==1.0.0']
-DEFAULT_NAME = 'HA Dockermon {0}'
+DEFAULT_NAME = 'HA Dockermon'
+CONTAINTER_NAME = '{} {}'
 
 CONF_CONTAINERS = 'containers'
 
@@ -85,12 +86,10 @@ class HADockermonSwitch(SwitchDevice):
         self.api = api
         self.container = container
         
-        if device_name and "{0}" in device_name:
-            self.device_name = device_name.format(self.container)
-        elif not device_name:
-            self.device_name = DEFAULT_NAME.format(self.container)
+        if device_name:
+            self.device_name = CONTAINTER_NAME.format(device_name, container)
         else:
-            self.device_name = device_name
+            self.device_name = CONTAINTER_NAME.format(DEFAULT_NAME, container)
         
         self._state = None
         self._host = host

--- a/custom_components/switch/hadockermon.py
+++ b/custom_components/switch/hadockermon.py
@@ -83,10 +83,15 @@ class HADockermonSwitch(SwitchDevice):
     def __init__(self, api, device_name, container, host):
         """Initialize a HA Dockermon switch."""
         self.api = api
-        self.device_name = device_name
         self.container = container
-        if not self.device_name:
+        
+        if device_name and "{0}" in device_name:
+            self.device_name = device_name.format(self.container)
+        elif not device_name:
             self.device_name = DEFAULT_NAME.format(self.container)
+        else:
+            self.device_name = device_name
+        
         self._state = None
         self._host = host
         self._status = None


### PR DESCRIPTION
This change allow us to set a custom name with formatting.

Example:
```yaml
- platform: hadockermon
  name: Docker
  host: 192.168.1.111
  port: 8126
```

If the container is named 'portainer', the switch will be switch.docker_portainer