### PR TITLE
Band-aid fix for >0.92

### DIFF
--- a/custom_components/hadockermon/__init__.py
+++ b/custom_components/hadockermon/__init__.py
@@ -1,0 +1,1 @@
+"""HA Dockermon Switch"""

--- a/custom_components/hadockermon/manifest.json
+++ b/custom_components/hadockermon/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "hadockermon",
+  "name": "HA Dockermon",
+  "documentation": "https://github.com/custom-components/switch.hadockermon",
+  "dependencies": [],
+  "codeowners": ["@ludeeus"],
+  "requirements": ["pydockermon==1.0.0"]
+}

--- a/custom_components/hadockermon/switch.py
+++ b/custom_components/hadockermon/switch.py
@@ -17,11 +17,10 @@ from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME,
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pydockermon==1.0.0']
 DEFAULT_NAME = 'HA Dockermon'
 CONTAINTER_NAME = '{} {}'
 


### PR DESCRIPTION
These changes seem to make 0.92.1 happy.
Just added in the new requirements of __init__.py and moved REQUIREMENTS to manifest.json
I guess these new files will have to be referenced wherever the stuff for custom_updater are, but I don't know where that is....